### PR TITLE
Fixed dataset anomalies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,8 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Images
+*.jpg
+project/scripts/data
+project/scripts/output

--- a/project/environment-preprocess.yml
+++ b/project/environment-preprocess.yml
@@ -189,7 +189,7 @@ dependencies:
   - numpy-base=2.2.5
   - ocl-icd=2.3.3
   - opencl-headers=2025.07.22
-  - opencv=4.13.0
+  #- opencv=4.13.0
   - openh264=2.6.0
   - openjpeg=2.5.4
   - openldap=2.6.12
@@ -302,6 +302,7 @@ dependencies:
       - gitpython==3.1.46
       - lightning-utilities==0.15.3
       - multidict==6.7.1
+      - opencv-python-headless==4.13.0.92
       - pi-heif==1.3.0
       - pillow-avif-plugin==1.5.5
       - platformdirs==4.9.4
@@ -311,6 +312,7 @@ dependencies:
       - pydantic-core==2.41.5
       - python-dotenv==1.2.2
       - pytorch-lightning==2.6.1
+      - roboflow
       - sentry-sdk==2.56.0
       - simsimd==6.5.16
       - smmap==5.0.3

--- a/project/scripts/classification_pipeline/datasets.py
+++ b/project/scripts/classification_pipeline/datasets.py
@@ -52,6 +52,7 @@ class ToothCropDataset(Dataset):
         return {
             "image_np": crop.astype(np.float32),
             "label": int(record["label"]),
+            "file_name": record.get("file_name", "unknown"),
             "record_id": record["record_id"],
             "source_image_id": int(record["source_image_id"]),
             "source_class": record["source_class"],
@@ -59,4 +60,5 @@ class ToothCropDataset(Dataset):
 
     def __getitem__(self, index: int):
         sample = self.get_raw_sample(index)
-        return to_chw_tensor(sample["image_np"]), torch.tensor(sample["label"], dtype=torch.long)
+        metadata = {"file_name": sample["file_name"]}
+        return to_chw_tensor(sample["image_np"]), torch.tensor(sample["label"], dtype=torch.long), metadata

--- a/project/scripts/classification_pipeline/download.py
+++ b/project/scripts/classification_pipeline/download.py
@@ -11,9 +11,9 @@ from roboflow import Roboflow
 
 @dataclass(frozen=True)
 class ClassificationDownloadConfig:
-    workspace: str = "wishis64"
-    project_name: str = "se-iwfnq"
-    version: int = 1
+    workspace: str = "sthes-workspace"
+    project_name: str = "se-iwfnq-4mlpj"
+    version: int = 2
     export_format: str = "coco-segmentation"
     data_root: Path = Path("data") / "classification"
     api_key: str | None = None

--- a/project/scripts/config.py
+++ b/project/scripts/config.py
@@ -1,0 +1,2 @@
+# Configuration file for the project
+OUTPUT_DIR = "output"

--- a/project/scripts/detection_pipeline/datasets.py
+++ b/project/scripts/detection_pipeline/datasets.py
@@ -31,6 +31,7 @@ class ToothDetectionDataset(Dataset):
             "boxes": np.asarray(transformed["bboxes"], dtype=np.float32).reshape(-1, 4),
             "labels": np.asarray(transformed["class_labels"], dtype=np.int64),
             "image_id": int(record["image_id"]),
+            "file_name": record["file_name"],
         }
 
     def __getitem__(self, index: int):
@@ -43,6 +44,7 @@ class ToothDetectionDataset(Dataset):
             "image_id": torch.tensor(sample["image_id"], dtype=torch.int64),
             "area": torch.from_numpy(area.astype(np.float32)),
             "iscrowd": torch.zeros((len(sample["labels"]),), dtype=torch.int64),
+            "file_name": sample["file_name"],
         }
         return to_chw_tensor(sample["image_np"]), target
 
@@ -67,6 +69,7 @@ class AugmentedToothDetectionDataset(Dataset):
             "image_id": torch.tensor(sample["image_id"], dtype=torch.int64),
             "area": torch.from_numpy(area.astype(np.float32)),
             "iscrowd": torch.zeros((len(labels),), dtype=torch.int64),
+            "file_name": sample["file_name"],
         }
         return to_chw_tensor(transformed["image"]), target
 

--- a/project/scripts/detection_pipeline/download.py
+++ b/project/scripts/detection_pipeline/download.py
@@ -11,8 +11,8 @@ from roboflow import Roboflow
 
 @dataclass(frozen=True)
 class DetectionDownloadConfig:
-    workspace: str = "mohamed-uob"
-    project_name: str = "denim"
+    workspace: str = "sthes-workspace"
+    project_name: str = "denim-eihop"
     version: int = 1
     export_format: str = "coco"
     data_root: Path = Path("data") / "detection"

--- a/project/scripts/run_example.py
+++ b/project/scripts/run_example.py
@@ -220,7 +220,7 @@ def main() -> None:
     _show_classification_examples("Classification val", classification_val, sample_count=20)
     _show_classification_examples("Classification test", classification_test, sample_count=20)
 
-    print("Close all figure windows to finish.")
+    print("Example images saved to output directory (scripts/output). See corresponding text files for original filenames.")
     plt.show()
 
 

--- a/project/scripts/run_example.py
+++ b/project/scripts/run_example.py
@@ -111,7 +111,7 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
     axes_arr = np.atleast_1d(axes).ravel()
 
     with open(txt_filepath, "w", encoding="utf-8") as f:
-        f.write(f"--- Classification file list: {name} ---\n")
+        f.write(f"--- File list for: {name} ---\n")
         f.write(f"Format: [Index in Plot] - [Original Filename]\n\n")
 
         for ax, idx in zip(axes_arr, indices):
@@ -135,6 +135,15 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
     plt.savefig(img_filepath)
     plt.close(fig)
 
+def split_records_by_subset(records: list[dict[str, Any]]):
+    """
+    Based on roboflow dataset structure, splits records into train/val/test based on 'subset' field.
+    """
+    train_rec = [r for r in records if r.get("subset") == "train"]
+    val_rec   = [r for r in records if r.get("subset") in ["valid", "val"]]
+    test_rec  = [r for r in records if r.get("subset") == "test"]
+    
+    return train_rec, val_rec, test_rec
 
 def main() -> None:
     os.makedirs(config.OUTPUT_DIR, exist_ok=True)
@@ -152,7 +161,7 @@ def main() -> None:
         force_download=force_download,
     )
     detection_records, tooth_label_map = build_detection_records(detection_coco, detection_image_dirs)
-    det_train, det_val, det_test = split_detection_records(detection_records)
+    det_train, det_val, det_test = split_records_by_subset(detection_records)
 
     detection_train = AugmentedToothDetectionDataset(
         ToothDetectionDataset(det_train, image_size=640, output_channels=3),
@@ -171,7 +180,7 @@ def main() -> None:
         positive_classes=("Caries",),
         crop_margin=0.08,
     )
-    cls_train, cls_val, cls_test = split_classification_records(classification_records)
+    cls_train, cls_val, cls_test = split_records_by_subset(classification_records)
 
     resize = build_classification_resize_pipeline(224)
     classification_train = ToothCropDataset(

--- a/project/scripts/run_example.py
+++ b/project/scripts/run_example.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import random
 import sys
+import config
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -52,33 +53,46 @@ def _show_detection_examples(name: str, dataset, sample_count: int = 20) -> None
         print(f"No samples available for {name}.")
         return
 
+    clean_name = name.replace(' ', '_').replace('(', '').replace(')', '')
+    txt_filepath = os.path.join(config.OUTPUT_DIR, f"{clean_name}_file_list.txt")
+    img_filepath = os.path.join(config.OUTPUT_DIR, f"{clean_name}.jpg")
+
     cols = 5
     rows = int(np.ceil(len(indices) / cols))
     fig, axes = plt.subplots(rows, cols, figsize=(4 * cols, 4 * rows))
     axes_arr = np.atleast_1d(axes).ravel()
 
-    for ax, idx in zip(axes_arr, indices):
-        image_tensor, target = dataset[idx]
-        image = _to_display_image(image_tensor)
-        ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
+    with open(txt_filepath, "w", encoding="utf-8") as f:
+        f.write(f"--- File list for: {name} ---\n")
+        f.write(f"Format: [Index in Plot] - [Original Filename]\n\n")
+        
+        for ax, idx in zip(axes_arr, indices):
+            image_tensor, target = dataset[idx]
+            image = _to_display_image(image_tensor)
+            ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
 
-        boxes = target["boxes"].detach().cpu().numpy()
-        labels = target["labels"].detach().cpu().numpy()
-        for box, label in zip(boxes, labels):
-            x1, y1, x2, y2 = box
-            rect = Rectangle((x1, y1), x2 - x1, y2 - y1, fill=False, linewidth=1.5, edgecolor="lime")
-            ax.add_patch(rect)
-            ax.text(x1, max(0.0, y1 - 3), str(int(label)), color="yellow", fontsize=8, backgroundcolor="black")
+            file_name = target.get("file_name", "Ismeretlen_fajl")
+            
+            f.write(f"{idx} - {file_name}\n")
 
-        ax.set_title(f"idx={idx} boxes={len(boxes)}", fontsize=9)
-        ax.axis("off")
+            boxes = target["boxes"].detach().cpu().numpy()
+            labels = target["labels"].detach().cpu().numpy()
+            for box, label in zip(boxes, labels):
+                x1, y1, x2, y2 = box
+                rect = Rectangle((x1, y1), x2 - x1, y2 - y1, fill=False, linewidth=1.5, edgecolor="lime")
+                ax.add_patch(rect)
+                ax.text(x1, max(0.0, y1 - 3), str(int(label)), color="yellow", fontsize=8, backgroundcolor="black")
+
+            ax.set_title(f"idx={idx}", fontsize=10, fontweight='bold')
+            ax.axis("off")
 
     for ax in axes_arr[len(indices):]:
         ax.axis("off")
 
     fig.suptitle(f"{name} - {len(indices)} examples", fontsize=14)
     fig.tight_layout()
-    plt.show(block=False)
+    plt.savefig(img_filepath)
+    plt.close(fig)
 
 
 def _show_classification_examples(name: str, dataset, sample_count: int = 20) -> None:
@@ -86,6 +100,10 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
     if not indices:
         print(f"No samples available for {name}.")
         return
+
+    clean_name = name.replace(' ', '_').replace('(', '').replace(')', '')
+
+    img_filepath = os.path.join(config.OUTPUT_DIR, f"{clean_name}.jpg")
 
     cols = 5
     rows = int(np.ceil(len(indices) / cols))
@@ -105,10 +123,13 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
 
     fig.suptitle(f"{name} - {len(indices)} examples", fontsize=14)
     fig.tight_layout()
-    plt.show(block=False)
+    plt.savefig(img_filepath)
+    plt.close(fig)
 
 
 def main() -> None:
+    os.makedirs(config.OUTPUT_DIR, exist_ok=True)
+
     api_key = os.getenv("ROBOFLOW_API_KEY")
     force_download = any(arg.lower() == "download" for arg in sys.argv[1:])
 

--- a/project/scripts/run_example.py
+++ b/project/scripts/run_example.py
@@ -100,9 +100,9 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
     if not indices:
         print(f"No samples available for {name}.")
         return
-
+    
     clean_name = name.replace(' ', '_').replace('(', '').replace(')', '')
-
+    txt_filepath = os.path.join(config.OUTPUT_DIR, f"{clean_name}_file_list.txt")
     img_filepath = os.path.join(config.OUTPUT_DIR, f"{clean_name}.jpg")
 
     cols = 5
@@ -110,13 +110,22 @@ def _show_classification_examples(name: str, dataset, sample_count: int = 20) ->
     fig, axes = plt.subplots(rows, cols, figsize=(4 * cols, 4 * rows))
     axes_arr = np.atleast_1d(axes).ravel()
 
-    for ax, idx in zip(axes_arr, indices):
-        image_tensor, label_tensor = dataset[idx]
-        image = _to_display_image(image_tensor)
-        label = int(label_tensor.item())
-        ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
-        ax.set_title(f"idx={idx} label={label}", fontsize=9)
-        ax.axis("off")
+    with open(txt_filepath, "w", encoding="utf-8") as f:
+        f.write(f"--- Classification file list: {name} ---\n")
+        f.write(f"Format: [Index in Plot] - [Original Filename]\n\n")
+
+        for ax, idx in zip(axes_arr, indices):
+            image_tensor, label_tensor, metadata = dataset[idx]
+            
+            image = _to_display_image(image_tensor)
+            label = int(label_tensor.item())
+            file_name = metadata.get("file_name", "unknown")
+
+            f.write(f"{idx} - {file_name}\n")
+
+            ax.imshow(image, cmap="gray" if image.ndim == 2 else None)
+            ax.set_title(f"idx={idx} L={label}", fontsize=10, fontweight='bold')
+            ax.axis("off")
 
     for ax in axes_arr[len(indices):]:
         ax.axis("off")


### PR DESCRIPTION
- Created new versions for the [detection ](https://app.roboflow.com/sthes-workspace/denim-eihop/1) / [classification ](https://app.roboflow.com/sthes-workspace/se-iwfnq-4mlpj/2) datasets on roboflow.
- Splits are now based on roboflow's dataset splits (70-15-15) -> only resize preprocess added 640x640 (this can be modified)
- The images now appear in the correct folder
- Some detection images had black borders
<img width="1343" height="947" alt="image" src="https://github.com/user-attachments/assets/84cf1379-690f-4cfa-8a5a-90a3eb98f41a" />
- The classification images were augmented offline (on Roboflow side), this was the reason for black squares and rotations on images
<img width="894" height="506" alt="image" src="https://github.com/user-attachments/assets/ec0c2c75-62bf-47a9-8abe-e34501316c28" />
- The plots will be exported to the output folder where the txts can be used to identify the original images
<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/ce5cadb0-5f99-445f-946f-ef08733dc933" />

close #1 
close #2 